### PR TITLE
Log 400 level errors at info level and 500 level errors at error level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Log request details upon error.  This includes X-Platform header, Authorization header, method, path, query, and body.
 
+400 level errors are logged at the info level, while 500 level errors are logged at the error level.
+
 ## usage
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ module.exports = function(logger) {
         requestQuery: this.request.query,
         requestBody: this.request.body
       };
-      logger.error({ requestDebugInfo, err }, 'koa-log-req-on-error: request encountered an error');
+      if (this.status < 500) {
+        logger.info({ requestDebugInfo, err }, 'koa-log-req-on-error: request encountered an error');
+      } else {
+        logger.error({ requestDebugInfo, err }, 'koa-log-req-on-error: request encountered an error');
+      }
 
       throw err;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-log-req-on-err",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "When an error occurs, log request details.",
   "main": "index.js",
   "scripts": {
@@ -12,9 +12,6 @@
     "url": "git+https://github.com/dtdd2l/koa-log-req-on-err.git"
   },
   "keywords": [
-    "postgresql",
-    "pgsql",
-    "pg",
     "http",
     "errors"
   ],
@@ -24,6 +21,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "eslint": "^1.6.0"
+    "eslint": "^3.19.0"
   }
 }


### PR DESCRIPTION
@dtdd2l need this change so that I don't get bombarded with alarm emails caused by 400 level errors which aren't actually something I need to be alerted about because it's the client using the service wrong, and nothing is actually wrong with the service.

Thanks 😄 